### PR TITLE
Add PostGIS function descriptions

### DIFF
--- a/src/PgConnectionArgFilterPostgisOperatorsPlugin.js
+++ b/src/PgConnectionArgFilterPostgisOperatorsPlugin.js
@@ -28,20 +28,20 @@ module.exports = function PgConnectionArgFilterPostgisOperatorsPlugin(builder) {
     let specs = [];
 
     // Functions
-    for (const [fn, baseTypeNames, fieldName] of [
-      ["ST_3DIntersects", [GEOMETRY], "intersects3D"],
-      ["ST_Contains", [GEOMETRY], "contains"],
-      ["ST_ContainsProperly", [GEOMETRY], "containsProperly"],
-      ["ST_CoveredBy", [GEOMETRY, GEOGRAPHY], "coveredBy"],
-      ["ST_Covers", [GEOMETRY, GEOGRAPHY], "covers"],
-      ["ST_Crosses", [GEOMETRY], "crosses"],
-      ["ST_Disjoint", [GEOMETRY], "disjoint"],
-      ["ST_Equals", [GEOMETRY], "equals"],
-      ["ST_Intersects", [GEOMETRY, GEOGRAPHY], "intersects"],
-      ["ST_OrderingEquals", [GEOMETRY], "orderingEquals"],
-      ["ST_Overlaps", [GEOMETRY], "overlaps"],
-      ["ST_Touches", [GEOMETRY], "touches"],
-      ["ST_Within", [GEOMETRY], "within"],
+    for (const [fn, baseTypeNames, fieldName, description] of [
+      ["ST_3DIntersects", [GEOMETRY], "intersects3D", "Returns TRUE if the Geometries 'spatially intersect' in 3d - only for points, linestrings, polygons, polyhedral surface (area). With SFCGAL backend enabled also supports TINS."],
+      ["ST_Contains", [GEOMETRY], "contains", "Returns TRUE if and only if no points of supplied lie in the exterior of field, and at least one point of the interior of supplied lies in the interior of field."],
+      ["ST_ContainsProperly", [GEOMETRY], "containsProperly", "Returns TRUE if supplied intersects the interior of field but not the boundary (or exterior). Field does not contain properly itself, but does contain itself."],
+      ["ST_CoveredBy", [GEOMETRY, GEOGRAPHY], "coveredBy", "Returns TRUE if no point in field Geometry/Geography is outside supplied Geometry/Geography."],
+      ["ST_Covers", [GEOMETRY, GEOGRAPHY], "covers", "Returns TRUE if no point in supplied Geometry is outside field Geometry."],
+      ["ST_Crosses", [GEOMETRY], "crosses", "Returns TRUE if the supplied geometries have some, but not all, interior points in common."],
+      ["ST_Disjoint", [GEOMETRY], "disjoint", "Returns TRUE if the Geometries do not 'spatially intersect' - if they do not share any space together."],
+      ["ST_Equals", [GEOMETRY], "equals", "Returns TRUE if the given geometries represent the same geometry. Directionality is ignored."],
+      ["ST_Intersects", [GEOMETRY, GEOGRAPHY], "intersects", "Returns TRUE if the Geometries/Geography 'spatially intersect in 2D' - (share any portion of space)."],
+      ["ST_OrderingEquals", [GEOMETRY], "orderingEquals", "Returns TRUE if the given geometries represent the same geometry and points are in the same directional order."],
+      ["ST_Overlaps", [GEOMETRY], "overlaps", "Returns TRUE if the Geometries share space, are of the same dimension, but are not completely contained by each other."],
+      ["ST_Touches", [GEOMETRY], "touches", "Returns TRUE if the geometries have at least one point in common, but their interiors do not intersect."],
+      ["ST_Within", [GEOMETRY], "within", "Returns TRUE if the geometry field is completely inside geometry supplied"],
     ]) {
       for (const baseTypeName of baseTypeNames) {
         const sqlGisFunction =
@@ -50,7 +50,7 @@ module.exports = function PgConnectionArgFilterPostgisOperatorsPlugin(builder) {
             : sql.identifier(pgGISExtension.namespaceName, fn.toLowerCase());
         specs.push({
           fieldName,
-          description: `Matches the specified ${baseTypeName} using the \`${fn}\` function.`,
+          description,
           resolveType: fieldType => fieldType,
           resolve: (i, v) => sql.query`${sqlGisFunction}(${i}, ${v})`,
           options: {
@@ -62,25 +62,25 @@ module.exports = function PgConnectionArgFilterPostgisOperatorsPlugin(builder) {
     }
 
     // Operators
-    for (const [op, baseTypeNames, fieldName] of [
-      ["=", [GEOMETRY, GEOGRAPHY], "exactlyEquals"],
-      ["&&", [GEOMETRY, GEOGRAPHY], "bboxIntersects2D"],
-      ["&&&", [GEOMETRY], "bboxIntersectsND"],
-      ["&<", [GEOMETRY], "bboxOverlapsOrLeftOf"],
-      ["&<|", [GEOMETRY], "bboxOverlapsOrBelow"],
-      ["&>", [GEOMETRY], "bboxOverlapsOrRightOf"],
-      ["|&>", [GEOMETRY], "bboxOverlapsOrAbove"],
-      ["<<", [GEOMETRY], "bboxLeftOf"],
-      ["<<|", [GEOMETRY], "bboxBelow"],
-      [">>", [GEOMETRY], "bboxRightOf"],
-      ["|>>", [GEOMETRY], "bboxAbove"],
-      ["~", [GEOMETRY], "bboxContains"],
-      ["~=", [GEOMETRY], "bboxEquals"],
+    for (const [op, baseTypeNames, fieldName, description] of [
+      ["=", [GEOMETRY, GEOGRAPHY], "exactlyEquals", "Returns TRUE if the coordinates and coordinate order geometry/geography field are the same as the coordinates and coordinate order of geometry/geography supplied."],
+      ["&&", [GEOMETRY, GEOGRAPHY], "bboxIntersects2D", "Returns TRUE if fields's 2D bounding box intersects supplied's 2D bounding box."],
+      ["&&&", [GEOMETRY], "bboxIntersectsND", "Returns TRUE if the coordinates and coordinate order geometry/geography field are the same as the coordinates and coordinate order of geometry/geography supplied."],
+      ["&<", [GEOMETRY], "bboxOverlapsOrLeftOf", "Returns TRUE if field's bounding box overlaps or is to the left of supplied's."],
+      ["&<|", [GEOMETRY], "bboxOverlapsOrBelow", "Returns TRUE if field's bounding box overlaps or is below supplied's."],
+      ["&>", [GEOMETRY], "bboxOverlapsOrRightOf", "Returns TRUE if field's bounding box overlaps or is to the right of supplied's."],
+      ["|&>", [GEOMETRY], "bboxOverlapsOrAbove", "Returns TRUE if field's bounding box overlaps or is above supplied's."],
+      ["<<", [GEOMETRY], "bboxLeftOf", "Returns TRUE if field's bounding box is strictly to the left of supplied's."],
+      ["<<|", [GEOMETRY], "bboxBelow", "Returns TRUE if field's bounding box is strictly below supplied's."],
+      [">>", [GEOMETRY], "bboxRightOf", "Returns TRUE if field's bounding box is strictly to the right of supplied's."],
+      ["|>>", [GEOMETRY], "bboxAbove", "Returns TRUE if field's bounding box is strictly above supplied's."],
+      ["~", [GEOMETRY], "bboxContains", "Returns TRUE if field's bounding box contains supplied's."],
+      ["~=", [GEOMETRY], "bboxEquals", "Returns TRUE if field's bounding box is the same as supplied's."],
     ]) {
       for (const baseTypeName of baseTypeNames) {
         specs.push({
           fieldName,
-          description: `Matches the specified ${baseTypeName} using the \`${op}\` operator.`,
+          description,
           resolveType: fieldType => fieldType,
           resolve: (i, v) => sql.query`${i} ${sql.raw(op)} ${v}`,
           options: {

--- a/src/PgConnectionArgFilterPostgisOperatorsPlugin.js
+++ b/src/PgConnectionArgFilterPostgisOperatorsPlugin.js
@@ -29,19 +29,19 @@ module.exports = function PgConnectionArgFilterPostgisOperatorsPlugin(builder) {
 
     // Functions
     for (const [fn, baseTypeNames, fieldName, description] of [
-      ["ST_3DIntersects", [GEOMETRY], "intersects3D", "Do the Geometries 'spatially intersect' in 3d - only for points, linestrings, polygons, polyhedral surface (area). With SFCGAL backend enabled also supports TINS."],
-      ["ST_Contains", [GEOMETRY], "contains", "If no point in specified Geometry/Geography is outside and at least one point is inside."],
-      ["ST_ContainsProperly", [GEOMETRY], "containsProperly", "If it intersects the interior but not the boundary (or exterior). Nothing can containsProperly itself, but can contain itself."],
-      ["ST_CoveredBy", [GEOMETRY, GEOGRAPHY], "coveredBy", "If no point in field Geometry/Geography is outside specified."],
-      ["ST_Covers", [GEOMETRY, GEOGRAPHY], "covers", "If no point is outside."],
-      ["ST_Crosses", [GEOMETRY], "crosses", "If there are some, but not all, interior points in common."],
-      ["ST_Disjoint", [GEOMETRY], "disjoint", "If they do not share any space together."],
-      ["ST_Equals", [GEOMETRY], "equals", "If they represent the same geometry. Directionality is ignored."],
-      ["ST_Intersects", [GEOMETRY, GEOGRAPHY], "intersects", "If they share any portion of space (in 2d)."],
-      ["ST_OrderingEquals", [GEOMETRY], "orderingEquals", "If they represent the same geometry and points are in the same directional order."],
-      ["ST_Overlaps", [GEOMETRY], "overlaps", "If they share space, are of the same dimension, but are not completely contained by each other."],
-      ["ST_Touches", [GEOMETRY], "touches", "If they have at least one point in common, but their interiors do not intersect."],
-      ["ST_Within", [GEOMETRY], "within", "If the geometry field is completely inside specified."],
+      ["ST_3DIntersects", [GEOMETRY], "intersects3D", "They share any portion of space in 3D."],
+      ["ST_Contains", [GEOMETRY], "contains", "No points of the specified geometry lie in the exterior, and at least one point of the interior of the specified geometry lies in the interior."],
+      ["ST_ContainsProperly", [GEOMETRY], "containsProperly", "The specified geometry intersects the interior but not the boundary (or exterior)."],
+      ["ST_CoveredBy", [GEOMETRY, GEOGRAPHY], "coveredBy", "No point is outside the specified geometry."],
+      ["ST_Covers", [GEOMETRY, GEOGRAPHY], "covers", "No point in the specified geometry is outside."],
+      ["ST_Crosses", [GEOMETRY], "crosses", "They have some, but not all, interior points in common."],
+      ["ST_Disjoint", [GEOMETRY], "disjoint", "They do not share any space together."],
+      ["ST_Equals", [GEOMETRY], "equals", "They represent the same geometry. Directionality is ignored."],
+      ["ST_Intersects", [GEOMETRY, GEOGRAPHY], "intersects", "They share any portion of space in 2D."],
+      ["ST_OrderingEquals", [GEOMETRY], "orderingEquals", "They represent the same geometry and points are in the same directional order."],
+      ["ST_Overlaps", [GEOMETRY], "overlaps", "They share space, are of the same dimension, but are not completely contained by each other."],
+      ["ST_Touches", [GEOMETRY], "touches", "They have at least one point in common, but their interiors do not intersect."],
+      ["ST_Within", [GEOMETRY], "within", "Completely inside the specified geometry."],
     ]) {
       for (const baseTypeName of baseTypeNames) {
         const sqlGisFunction =
@@ -63,19 +63,19 @@ module.exports = function PgConnectionArgFilterPostgisOperatorsPlugin(builder) {
 
     // Operators
     for (const [op, baseTypeNames, fieldName, description] of [
-      ["=", [GEOMETRY, GEOGRAPHY], "exactlyEquals", "If the coordinates and coordinate order geometry/geography are the same ."],
-      ["&&", [GEOMETRY, GEOGRAPHY], "bboxIntersects2D", "If 2D bounding boxes intersect each other."],
-      ["&&&", [GEOMETRY], "bboxIntersectsND", "If the coordinates and coordinate order geometry/geography are the same."],
-      ["&<", [GEOMETRY], "bboxOverlapsOrLeftOf", "If the bounding box overlaps or is to the left of specified."],
-      ["&<|", [GEOMETRY], "bboxOverlapsOrBelow", "If the bounding box overlaps or is below specified."],
-      ["&>", [GEOMETRY], "bboxOverlapsOrRightOf", "If the bounding box overlaps or is to the right of specified."],
-      ["|&>", [GEOMETRY], "bboxOverlapsOrAbove", "If the bounding box overlaps or is above specified."],
-      ["<<", [GEOMETRY], "bboxLeftOf", "If the bounding box is strictly to the left of specified."],
-      ["<<|", [GEOMETRY], "bboxBelow", "If the bounding box is strictly below specified."],
-      [">>", [GEOMETRY], "bboxRightOf", "If the bounding box is strictly to the right of specified."],
-      ["|>>", [GEOMETRY], "bboxAbove", "If the bounding box is strictly above specified."],
-      ["~", [GEOMETRY], "bboxContains", "If the bounding box contains specified."],
-      ["~=", [GEOMETRY], "bboxEquals", "If the bounding box is the same as specified."],
+      ["=", [GEOMETRY, GEOGRAPHY], "exactlyEquals", "Coordinates and coordinate order are the same as specified geometry."],
+      ["&&", [GEOMETRY, GEOGRAPHY], "bboxIntersects2D", "2D bounding box intersects the specified geometry's 2D bounding box."],
+      ["&&&", [GEOMETRY], "bboxIntersectsND", "n-D bounding box intersects the specified geometry's n-D bounding box."],
+      ["&<", [GEOMETRY], "bboxOverlapsOrLeftOf", "Bounding box overlaps or is to the left of the specified geometry's bounding box."],
+      ["&<|", [GEOMETRY], "bboxOverlapsOrBelow", "Bounding box overlaps or is below the specified geometry's bounding box."],
+      ["&>", [GEOMETRY], "bboxOverlapsOrRightOf", "Bounding box overlaps or is to the right of the specified geometry's bounding box."],
+      ["|&>", [GEOMETRY], "bboxOverlapsOrAbove", "Bounding box overlaps or is above the specified geometry's bounding box."],
+      ["<<", [GEOMETRY], "bboxLeftOf", "Bounding box is strictly to the left of the specified geometry's bounding box."],
+      ["<<|", [GEOMETRY], "bboxBelow", "Bounding box is strictly below the specified geometry's bounding box."],
+      [">>", [GEOMETRY], "bboxRightOf", "Bounding box is strictly to the right of the specified geometry's bounding box."],
+      ["|>>", [GEOMETRY], "bboxAbove", "Bounding box is strictly above the specified geometry's bounding box."],
+      ["~", [GEOMETRY], "bboxContains", "Bounding box contains the specified geometry's bounding box."],
+      ["~=", [GEOMETRY], "bboxEquals", "Bounding box is the same as the specified geometry's bounding box."],
     ]) {
       for (const baseTypeName of baseTypeNames) {
         specs.push({

--- a/src/PgConnectionArgFilterPostgisOperatorsPlugin.js
+++ b/src/PgConnectionArgFilterPostgisOperatorsPlugin.js
@@ -29,19 +29,19 @@ module.exports = function PgConnectionArgFilterPostgisOperatorsPlugin(builder) {
 
     // Functions
     for (const [fn, baseTypeNames, fieldName, description] of [
-      ["ST_3DIntersects", [GEOMETRY], "intersects3D", "Returns TRUE if the Geometries 'spatially intersect' in 3d - only for points, linestrings, polygons, polyhedral surface (area). With SFCGAL backend enabled also supports TINS."],
-      ["ST_Contains", [GEOMETRY], "contains", "Returns TRUE if and only if no points of supplied lie in the exterior of field, and at least one point of the interior of supplied lies in the interior of field."],
-      ["ST_ContainsProperly", [GEOMETRY], "containsProperly", "Returns TRUE if supplied intersects the interior of field but not the boundary (or exterior). Field does not contain properly itself, but does contain itself."],
-      ["ST_CoveredBy", [GEOMETRY, GEOGRAPHY], "coveredBy", "Returns TRUE if no point in field Geometry/Geography is outside supplied Geometry/Geography."],
-      ["ST_Covers", [GEOMETRY, GEOGRAPHY], "covers", "Returns TRUE if no point in supplied Geometry is outside field Geometry."],
-      ["ST_Crosses", [GEOMETRY], "crosses", "Returns TRUE if the supplied geometries have some, but not all, interior points in common."],
-      ["ST_Disjoint", [GEOMETRY], "disjoint", "Returns TRUE if the Geometries do not 'spatially intersect' - if they do not share any space together."],
-      ["ST_Equals", [GEOMETRY], "equals", "Returns TRUE if the given geometries represent the same geometry. Directionality is ignored."],
-      ["ST_Intersects", [GEOMETRY, GEOGRAPHY], "intersects", "Returns TRUE if the Geometries/Geography 'spatially intersect in 2D' - (share any portion of space)."],
-      ["ST_OrderingEquals", [GEOMETRY], "orderingEquals", "Returns TRUE if the given geometries represent the same geometry and points are in the same directional order."],
-      ["ST_Overlaps", [GEOMETRY], "overlaps", "Returns TRUE if the Geometries share space, are of the same dimension, but are not completely contained by each other."],
-      ["ST_Touches", [GEOMETRY], "touches", "Returns TRUE if the geometries have at least one point in common, but their interiors do not intersect."],
-      ["ST_Within", [GEOMETRY], "within", "Returns TRUE if the geometry field is completely inside geometry supplied"],
+      ["ST_3DIntersects", [GEOMETRY], "intersects3D", "Do the Geometries 'spatially intersect' in 3d - only for points, linestrings, polygons, polyhedral surface (area). With SFCGAL backend enabled also supports TINS."],
+      ["ST_Contains", [GEOMETRY], "contains", "If no point in specified Geometry/Geography is outside and at least one point is inside."],
+      ["ST_ContainsProperly", [GEOMETRY], "containsProperly", "If it intersects the interior but not the boundary (or exterior). Nothing can containsProperly itself, but can contain itself."],
+      ["ST_CoveredBy", [GEOMETRY, GEOGRAPHY], "coveredBy", "If no point in field Geometry/Geography is outside specified."],
+      ["ST_Covers", [GEOMETRY, GEOGRAPHY], "covers", "If no point is outside."],
+      ["ST_Crosses", [GEOMETRY], "crosses", "If there are some, but not all, interior points in common."],
+      ["ST_Disjoint", [GEOMETRY], "disjoint", "If they do not share any space together."],
+      ["ST_Equals", [GEOMETRY], "equals", "If they represent the same geometry. Directionality is ignored."],
+      ["ST_Intersects", [GEOMETRY, GEOGRAPHY], "intersects", "If they share any portion of space (in 2d)."],
+      ["ST_OrderingEquals", [GEOMETRY], "orderingEquals", "If they represent the same geometry and points are in the same directional order."],
+      ["ST_Overlaps", [GEOMETRY], "overlaps", "If they share space, are of the same dimension, but are not completely contained by each other."],
+      ["ST_Touches", [GEOMETRY], "touches", "If they have at least one point in common, but their interiors do not intersect."],
+      ["ST_Within", [GEOMETRY], "within", "If the geometry field is completely inside specified."],
     ]) {
       for (const baseTypeName of baseTypeNames) {
         const sqlGisFunction =
@@ -63,19 +63,19 @@ module.exports = function PgConnectionArgFilterPostgisOperatorsPlugin(builder) {
 
     // Operators
     for (const [op, baseTypeNames, fieldName, description] of [
-      ["=", [GEOMETRY, GEOGRAPHY], "exactlyEquals", "Returns TRUE if the coordinates and coordinate order geometry/geography field are the same as the coordinates and coordinate order of geometry/geography supplied."],
-      ["&&", [GEOMETRY, GEOGRAPHY], "bboxIntersects2D", "Returns TRUE if fields's 2D bounding box intersects supplied's 2D bounding box."],
-      ["&&&", [GEOMETRY], "bboxIntersectsND", "Returns TRUE if the coordinates and coordinate order geometry/geography field are the same as the coordinates and coordinate order of geometry/geography supplied."],
-      ["&<", [GEOMETRY], "bboxOverlapsOrLeftOf", "Returns TRUE if field's bounding box overlaps or is to the left of supplied's."],
-      ["&<|", [GEOMETRY], "bboxOverlapsOrBelow", "Returns TRUE if field's bounding box overlaps or is below supplied's."],
-      ["&>", [GEOMETRY], "bboxOverlapsOrRightOf", "Returns TRUE if field's bounding box overlaps or is to the right of supplied's."],
-      ["|&>", [GEOMETRY], "bboxOverlapsOrAbove", "Returns TRUE if field's bounding box overlaps or is above supplied's."],
-      ["<<", [GEOMETRY], "bboxLeftOf", "Returns TRUE if field's bounding box is strictly to the left of supplied's."],
-      ["<<|", [GEOMETRY], "bboxBelow", "Returns TRUE if field's bounding box is strictly below supplied's."],
-      [">>", [GEOMETRY], "bboxRightOf", "Returns TRUE if field's bounding box is strictly to the right of supplied's."],
-      ["|>>", [GEOMETRY], "bboxAbove", "Returns TRUE if field's bounding box is strictly above supplied's."],
-      ["~", [GEOMETRY], "bboxContains", "Returns TRUE if field's bounding box contains supplied's."],
-      ["~=", [GEOMETRY], "bboxEquals", "Returns TRUE if field's bounding box is the same as supplied's."],
+      ["=", [GEOMETRY, GEOGRAPHY], "exactlyEquals", "If the coordinates and coordinate order geometry/geography are the same ."],
+      ["&&", [GEOMETRY, GEOGRAPHY], "bboxIntersects2D", "If 2D bounding boxes intersect each other."],
+      ["&&&", [GEOMETRY], "bboxIntersectsND", "If the coordinates and coordinate order geometry/geography are the same."],
+      ["&<", [GEOMETRY], "bboxOverlapsOrLeftOf", "If the bounding box overlaps or is to the left of specified."],
+      ["&<|", [GEOMETRY], "bboxOverlapsOrBelow", "If the bounding box overlaps or is below specified."],
+      ["&>", [GEOMETRY], "bboxOverlapsOrRightOf", "If the bounding box overlaps or is to the right of specified."],
+      ["|&>", [GEOMETRY], "bboxOverlapsOrAbove", "If the bounding box overlaps or is above specified."],
+      ["<<", [GEOMETRY], "bboxLeftOf", "If the bounding box is strictly to the left of specified."],
+      ["<<|", [GEOMETRY], "bboxBelow", "If the bounding box is strictly below specified."],
+      [">>", [GEOMETRY], "bboxRightOf", "If the bounding box is strictly to the right of specified."],
+      ["|>>", [GEOMETRY], "bboxAbove", "If the bounding box is strictly above specified."],
+      ["~", [GEOMETRY], "bboxContains", "If the bounding box contains specified."],
+      ["~=", [GEOMETRY], "bboxEquals", "If the bounding box is the same as specified."],
     ]) {
       for (const baseTypeName of baseTypeNames) {
         specs.push({


### PR DESCRIPTION
This is copied almost verbatim from the docs - https://postgis.net/docs/reference.html - with a few changes - casing on `true` -> `TRUE` has been fixed, and all `A` changed to `field` and `B` changed to `supplied`.